### PR TITLE
feat : 기본 셋팅 가이드

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### mac os ###
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -28,21 +28,33 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	//security 관련 설정
 //	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor("com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta")
+	annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+	annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	runtimeOnly 'com.h2database:h2'
 
-	//mockito
-	testImplementation "org.junit.platform:junit-platform-launcher:1.5.2"
-	testImplementation "org.junit.jupiter:junit-jupiter:5.5.2"
-	testImplementation "org.mockito:mockito-core:3.12.4"
 }
 
 test {

--- a/src/main/java/com/study/ducks/AppRunnerTest.java
+++ b/src/main/java/com/study/ducks/AppRunnerTest.java
@@ -1,0 +1,33 @@
+package com.study.ducks;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Slf4j
+@Component
+@Profile({"local", "dev"})
+public class AppRunnerTest implements ApplicationRunner {
+    private final Environment environment;
+
+    public AppRunnerTest(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("=================== Property Test ===================");
+        log.info("Active profiles : {}", Arrays.toString(environment.getActiveProfiles()));
+        log.info("Datasource driver : {}", environment.getProperty("spring.datasource.driver-class-name"));
+        log.info("Datasource url : {}", environment.getProperty("spring.datasource.url"));
+        log.info("Datasource username : {}", environment.getProperty("spring.datasource.username"));
+        log.info("Server Port : {}", environment.getProperty("server.port"));
+        log.info("Server url : {}", environment.getProperty("server.url"));
+        log.info("=====================================================");
+    }
+}

--- a/src/main/java/com/study/ducks/config/SecurityConfig.java
+++ b/src/main/java/com/study/ducks/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package com.study.ducks.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer(){
+        return web -> web.ignoring()
+                .requestMatchers("/h2-console/**")
+                .requestMatchers( "/favicon.ico")
+                .requestMatchers( "/error")
+                .requestMatchers( "/api/docs")
+                .requestMatchers( "/api/swagger-ui/**")
+                .requestMatchers( "/swagger-resources/**")
+                .requestMatchers( "/v3/api-docs/**");
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(requests -> requests
+                        .anyRequest().permitAll()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/study/ducks/config/SwaggerConfig.java
+++ b/src/main/java/com/study/ducks/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.study.ducks.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Value("${server.url}")
+    private String serverUrl;
+    @Bean
+    public OpenAPI openAPI() {
+
+        Server server = new Server();
+        server.setUrl(serverUrl);
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo())
+                .servers(List.of(server));
+    }
+    private Info apiInfo() {
+        return new Info()
+                .title("ducks API")
+                .description("ducks API 입니다.")
+                .version("1.0.0");
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,21 @@
+server:
+  url: "https://dev.ducks.site"
+  port: 8081
+  servlet:
+    encoding:
+      force-response: true
+
+spring:
+  datasource:
+    url: jdbc:mariadb://${DEV_DB_ENDPOINT}:3306/${DEV_DB_NAME}
+    username: ${DEV_DB_USERNAME}
+    password: ${DEV_DB_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,31 @@
+server:
+  url: "http://localhost"
+  port: 80
+  servlet:
+    encoding:
+      force-response: true
+    session:
+      cookie:
+        secure: false
+
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
+    driver-class-name: ${LOCAL_DB_DRIVER}
+  jpa:
+    hibernate:
+      ddl-auto: create
+  session:
+    jdbc:
+      initialize-schema: always
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,26 @@
+server:
+  url: "https://api.ducks.site"
+  port: 8080
+
+spring:
+  datasource:
+    url: jdbc:mariadb://${PROD_DB_ENDPOINT}:3306/${PROD_DB_NAME}
+    username: ${PROD_DB_USERNAME}
+    password: ${PROD_DB_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+logging:
+  level:
+    org.hibernate.SQL: info
+    org.hibernate.orm.jdbc.bind: info
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=ducks

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,32 @@
+spring:
+  application:
+    name: ducks
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+    open-in-view: true
+server:
+  servlet:
+    session:
+      cookie:
+        path: /
+        http-only: true
+        secure: true
+
+springdoc:
+  packages-to-scan: com.study.ducks
+  default-consumes-media-type: application/json;
+  default-produces-media-type: application/json;
+  show-actuator: true
+  swagger-ui:
+    path: /api/docs
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: method
+    tags-sorter: alpha
+    default-model-expand-depth: 2
+
+
+


### PR DESCRIPTION
### 1. build.gradle 의존성 추가
 - validation
 - swagger
 - querydsl
 - jwt
 - mariadb

* mockito는 과거의 특정 버전을 명시하고있어 삭제하였음. 
mockito는 기존 'org.springframework.boot:spring-boot-starter-test'에 포함되어있어 있음. 특정 버전을 꼭 사용해야하는 경우가 아니라면 필요 없음.

### 2. gitignore 내용 추가
 - mac 관련 파일 추가

### 3. appliction.yml 설정 추가
 - local, dev, prod 환경 분리
 - 사진은 local, h2-console 사용 예시. 다른 db사용 해도됨
![스크린샷 2025-03-09 오전 11 09 18](https://github.com/user-attachments/assets/83493625-5067-4115-b0d7-009d3394656c)


### 4.환경 변수 출력 로그 추가
 - 정상적으로 셋팅되어 서비스 시작됨을 확인.
![스크린샷 2025-03-09 오전 11 15 32](https://github.com/user-attachments/assets/8a041833-7bd5-405b-946a-408b7c193d8d)

### 5. 스웨거 및 스프링 시큐리티 기본 config 추가

