### PR TITLE
feat : error처리, config설정, 테스트코드 및 기본 모듈 작성

### DIFF
--- a/http/auth.http
+++ b/http/auth.http
@@ -1,0 +1,9 @@
+### 회원가입 테스트
+
+POST http://localhost/auth/signup
+Content-Type: application/json
+
+{
+    "loginId" : "test",
+    "password" : "1234"
+}

--- a/src/main/java/com/study/ducks/common/BaseTimeEntity.java
+++ b/src/main/java/com/study/ducks/common/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.study.ducks.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/study/ducks/config/JpaAuditingConfig.java
+++ b/src/main/java/com/study/ducks/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.study.ducks.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/study/ducks/config/QuerydslConfig.java
+++ b/src/main/java/com/study/ducks/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.study.ducks.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/study/ducks/config/SecurityConfig.java
+++ b/src/main/java/com/study/ducks/config/SecurityConfig.java
@@ -5,6 +5,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -29,6 +32,12 @@ public class SecurityConfig {
                 .authorizeHttpRequests(requests -> requests
                         .anyRequest().permitAll()
                 )
+                .csrf(AbstractHttpConfigurer::disable)
                 .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/study/ducks/domain/commission/entity/Commission.java
+++ b/src/main/java/com/study/ducks/domain/commission/entity/Commission.java
@@ -1,0 +1,42 @@
+package com.study.ducks.domain.commission.entity;
+
+import com.study.ducks.common.BaseTimeEntity;
+import com.study.ducks.domain.commission.enums.CommissionStatus;
+import com.study.ducks.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Commission extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commissionId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private CommissionStatus commissionStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Builder
+    public Commission(String title, String content, CommissionStatus commissionStatus, User user) {
+        this.title = title;
+        this.content = content;
+        this.commissionStatus = commissionStatus;
+        this.user = user;
+    }
+
+}

--- a/src/main/java/com/study/ducks/domain/commission/entity/CommissionReview.java
+++ b/src/main/java/com/study/ducks/domain/commission/entity/CommissionReview.java
@@ -1,0 +1,38 @@
+package com.study.ducks.domain.commission.entity;
+
+import com.study.ducks.common.BaseTimeEntity;
+import com.study.ducks.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CommissionReview extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commissionReviewId;
+
+    private byte rating;
+
+    @Lob
+    @Column(nullable = false)
+    private String comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Commission commission;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Builder
+    public CommissionReview(byte rating, String comment, Commission commission, User user) {
+        this.rating = rating;
+        this.comment = comment;
+        this.commission = commission;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/study/ducks/domain/commission/entity/CommissionUser.java
+++ b/src/main/java/com/study/ducks/domain/commission/entity/CommissionUser.java
@@ -1,0 +1,41 @@
+package com.study.ducks.domain.commission.entity;
+
+import com.study.ducks.common.BaseTimeEntity;
+import com.study.ducks.domain.commission.enums.CommissionStatus;
+import com.study.ducks.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CommissionUser extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commissionUserId;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private CommissionStatus commissionStatus;
+
+    private LocalDateTime complete_at;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Commission commission;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Builder
+    public CommissionUser(CommissionStatus commissionStatus, LocalDateTime complete_at, Commission commission, User user) {
+        this.commissionStatus = commissionStatus;
+        this.complete_at = complete_at;
+        this.commission = commission;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/study/ducks/domain/commission/enums/CommissionStatus.java
+++ b/src/main/java/com/study/ducks/domain/commission/enums/CommissionStatus.java
@@ -1,0 +1,16 @@
+package com.study.ducks.domain.commission.enums;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public enum CommissionStatus {
+    REQUESTED("요청"),
+    IN_PROGRESS("진행중"),
+    COMPLETED("완료"),
+    CANCELLED("취소");
+
+    private final String description;
+}

--- a/src/main/java/com/study/ducks/domain/commission/repository/CommissionRepository.java
+++ b/src/main/java/com/study/ducks/domain/commission/repository/CommissionRepository.java
@@ -1,0 +1,10 @@
+package com.study.ducks.domain.commission.repository;
+
+import com.study.ducks.domain.commission.entity.Commission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommissionRepository extends JpaRepository<Commission, Long> {
+
+}

--- a/src/main/java/com/study/ducks/domain/commission/repository/CommissionReviewRepository.java
+++ b/src/main/java/com/study/ducks/domain/commission/repository/CommissionReviewRepository.java
@@ -1,0 +1,9 @@
+package com.study.ducks.domain.commission.repository;
+
+import com.study.ducks.domain.commission.entity.CommissionReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommissionReviewRepository extends JpaRepository<CommissionReview, Long> {
+}

--- a/src/main/java/com/study/ducks/domain/commission/repository/CommissionUserRepository.java
+++ b/src/main/java/com/study/ducks/domain/commission/repository/CommissionUserRepository.java
@@ -1,0 +1,9 @@
+package com.study.ducks.domain.commission.repository;
+
+import com.study.ducks.domain.commission.entity.CommissionUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommissionUserRepository extends JpaRepository<CommissionUser, Long> {
+}

--- a/src/main/java/com/study/ducks/domain/commission/service/CommissionReviewService.java
+++ b/src/main/java/com/study/ducks/domain/commission/service/CommissionReviewService.java
@@ -1,0 +1,4 @@
+package com.study.ducks.domain.commission.service;
+
+public interface CommissionReviewService {
+}

--- a/src/main/java/com/study/ducks/domain/commission/service/CommissionService.java
+++ b/src/main/java/com/study/ducks/domain/commission/service/CommissionService.java
@@ -1,0 +1,4 @@
+package com.study.ducks.domain.commission.service;
+
+public interface CommissionService {
+}

--- a/src/main/java/com/study/ducks/domain/commission/service/CommissionUserService.java
+++ b/src/main/java/com/study/ducks/domain/commission/service/CommissionUserService.java
@@ -1,0 +1,4 @@
+package com.study.ducks.domain.commission.service;
+
+public interface CommissionUserService {
+}

--- a/src/main/java/com/study/ducks/domain/user/controller/UserController.java
+++ b/src/main/java/com/study/ducks/domain/user/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.study.ducks.domain.user.controller;
+
+import com.study.ducks.domain.user.dto.UserSignupRequest;
+import com.study.ducks.domain.user.dto.UserSignupResponse;
+import com.study.ducks.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "회원가입 API", description = "회원가입 API 입니다.")
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "일반 회원가입", description = "일반 회원가입 API 입니다.")
+    @PostMapping("/auth/signup")
+    public ResponseEntity<UserSignupResponse> signup(@RequestBody @Validated UserSignupRequest userSignupRequest){
+        return ResponseEntity.ok()
+                .body(userService.signup(userSignupRequest));
+    }
+
+}

--- a/src/main/java/com/study/ducks/domain/user/dto/UserSignupRequest.java
+++ b/src/main/java/com/study/ducks/domain/user/dto/UserSignupRequest.java
@@ -1,0 +1,14 @@
+package com.study.ducks.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(title = "회원가입 요청")
+public record UserSignupRequest(
+        @Schema(description = "아이디", example = "qwerty")
+        @NotBlank(message = "아이디를 입력해주세요")
+        String loginId,
+        @Schema(description = "비밀번호", example = "1234")
+        @NotBlank(message = "비밀번호를 입력해주세요")
+        String password
+) {}

--- a/src/main/java/com/study/ducks/domain/user/dto/UserSignupRequest.java
+++ b/src/main/java/com/study/ducks/domain/user/dto/UserSignupRequest.java
@@ -2,6 +2,7 @@ package com.study.ducks.domain.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
 @Schema(title = "회원가입 요청")
 public record UserSignupRequest(
@@ -11,4 +12,11 @@ public record UserSignupRequest(
         @Schema(description = "비밀번호", example = "1234")
         @NotBlank(message = "비밀번호를 입력해주세요")
         String password
-) {}
+)
+{
+        @Builder
+        public UserSignupRequest(String loginId, String password) {
+                this.loginId = loginId;
+                this.password = password;
+        }
+}

--- a/src/main/java/com/study/ducks/domain/user/dto/UserSignupResponse.java
+++ b/src/main/java/com/study/ducks/domain/user/dto/UserSignupResponse.java
@@ -1,0 +1,4 @@
+package com.study.ducks.domain.user.dto;
+
+public record UserSignupResponse(Long id, String loginId) {
+}

--- a/src/main/java/com/study/ducks/domain/user/entity/User.java
+++ b/src/main/java/com/study/ducks/domain/user/entity/User.java
@@ -1,0 +1,44 @@
+package com.study.ducks.domain.user.entity;
+
+import com.study.ducks.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+    private String loginId;
+    private String password;
+    //private String name;
+    private String nickname;
+    private String address;
+    private String countryCode;
+    private String phone;
+    private String role;
+    private String email;
+    private Boolean isAuth;
+    private Boolean isActive;
+
+    @Builder
+    public User(String loginId, String password, String nickname, String address, String countryCode, String phone, String role, String email, Boolean isAuth, Boolean isActive) {
+        this.loginId = loginId;
+        this.password = password;
+        this.nickname = nickname;
+        this.address = address;
+        this.countryCode = countryCode;
+        this.phone = phone;
+        this.role = role;
+        this.email = email;
+        this.isAuth = isAuth;
+        this.isActive = isActive;
+    }
+}

--- a/src/main/java/com/study/ducks/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/study/ducks/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.study.ducks.domain.user.repository;
+
+import com.study.ducks.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    //Optional<User> findByLoginIdAndPassword(String loginId, String password);
+    Optional<User> findByLoginId(String loginId);
+}

--- a/src/main/java/com/study/ducks/domain/user/service/UserService.java
+++ b/src/main/java/com/study/ducks/domain/user/service/UserService.java
@@ -1,0 +1,8 @@
+package com.study.ducks.domain.user.service;
+
+import com.study.ducks.domain.user.dto.UserSignupRequest;
+import com.study.ducks.domain.user.dto.UserSignupResponse;
+
+public interface UserService {
+    UserSignupResponse signup(UserSignupRequest userSignupRequest);
+}

--- a/src/main/java/com/study/ducks/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/study/ducks/domain/user/service/UserServiceImpl.java
@@ -25,7 +25,7 @@ public class UserServiceImpl implements UserService{
 
         Optional<User> user = userRepository.findByLoginId(userSignupRequest.loginId());
 
-        //if(user.isPresent()) throw new isExistedUser();
+        //if(user.isPresent()) throw new IsExistedUser();
         //todo exception 관련 작업 후 적용 예정
 
         String encode = passwordEncoder.encode(userSignupRequest.password());

--- a/src/main/java/com/study/ducks/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/study/ducks/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,40 @@
+package com.study.ducks.domain.user.service;
+
+import com.study.ducks.domain.user.dto.UserSignupRequest;
+import com.study.ducks.domain.user.dto.UserSignupResponse;
+import com.study.ducks.domain.user.entity.User;
+import com.study.ducks.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    @Override
+    public UserSignupResponse signup(UserSignupRequest userSignupRequest) {
+
+        Optional<User> user = userRepository.findByLoginId(userSignupRequest.loginId());
+
+        //if(user.isPresent()) throw new isExistedUser();
+        //todo exception 관련 작업 후 적용 예정
+
+        String encode = passwordEncoder.encode(userSignupRequest.password());
+
+        User signUpUser = userRepository.save(User.builder()
+                .loginId(userSignupRequest.loginId())
+                .password(encode)
+                .build());
+
+        return new UserSignupResponse(signUpUser.getUserId(), signUpUser.getLoginId());
+    }
+}

--- a/src/main/java/com/study/ducks/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/study/ducks/domain/user/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import com.study.ducks.domain.user.dto.UserSignupRequest;
 import com.study.ducks.domain.user.dto.UserSignupResponse;
 import com.study.ducks.domain.user.entity.User;
 import com.study.ducks.domain.user.repository.UserRepository;
+import com.study.ducks.exception.custom.IsExistedUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -25,8 +26,7 @@ public class UserServiceImpl implements UserService{
 
         Optional<User> user = userRepository.findByLoginId(userSignupRequest.loginId());
 
-        //if(user.isPresent()) throw new IsExistedUser();
-        //todo exception 관련 작업 후 적용 예정
+        if(user.isPresent()) throw new IsExistedUser();
 
         String encode = passwordEncoder.encode(userSignupRequest.password());
 

--- a/src/main/java/com/study/ducks/exception/ApiException.java
+++ b/src/main/java/com/study/ducks/exception/ApiException.java
@@ -1,0 +1,11 @@
+package com.study.ducks.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class ApiException extends RuntimeException{
+    public ApiException(String message) {
+        super(message);
+    }
+    public abstract int getStatusCode();
+}

--- a/src/main/java/com/study/ducks/exception/ErrorResponse.java
+++ b/src/main/java/com/study/ducks/exception/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.study.ducks.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ErrorResponse(Integer code, String message, Map<String, String> validation) {
+    @Builder
+    public ErrorResponse(Integer code, String message, Map<String, String> validation) {
+        this.code = code;
+        this.message = message == null ? "" : message;
+        this.validation = validation == null ? new HashMap<>() : validation;
+    }
+}

--- a/src/main/java/com/study/ducks/exception/ExceptionController.java
+++ b/src/main/java/com/study/ducks/exception/ExceptionController.java
@@ -1,0 +1,64 @@
+package com.study.ducks.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+@Slf4j
+public class ExceptionController {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> validException(MethodArgumentNotValidException e){
+
+        Map<String, String> validation = new HashMap<>();
+
+        for (FieldError error : e.getFieldErrors()) {
+            validation.put(error.getField(), error.getDefaultMessage());
+        }
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code(HttpStatus.BAD_REQUEST.value())
+                .message("잘못된 요청입니다.")
+                .validation(validation)
+                .build();
+
+        return ResponseEntity
+                .badRequest()
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> exception(ApiException e){
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code(e.getStatusCode())
+                .message(e.getMessage())
+                .build();
+
+        return ResponseEntity
+                .status(e.getStatusCode())
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> defaultException(Exception e){
+
+        log.error("Exception : ", e);
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .message("관리자에게 문의해주세요.")
+                .build();
+
+        return ResponseEntity
+                .internalServerError()
+                .body(errorResponse);
+    }
+}

--- a/src/main/java/com/study/ducks/exception/custom/IsExistedUser.java
+++ b/src/main/java/com/study/ducks/exception/custom/IsExistedUser.java
@@ -1,0 +1,14 @@
+package com.study.ducks.exception.custom;
+
+import com.study.ducks.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class IsExistedUser extends ApiException {
+    public IsExistedUser() {
+        super("이미 존재하는 아이디입니다.");
+    }
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+}

--- a/src/test/java/com/study/ducks/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/ducks/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,75 @@
+package com.study.ducks.domain.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.ducks.domain.user.dto.UserSignupRequest;
+import com.study.ducks.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private EntityManager em;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 확인")
+    void signup() throws Exception {
+        //given
+        UserSignupRequest userSignupRequest = UserSignupRequest.builder()
+                .loginId("testId")
+                .password("1234")
+                .build();
+
+        String json = objectMapper.writeValueAsString(userSignupRequest);
+
+        //expected
+        mockMvc.perform(MockMvcRequestBuilders.post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName("비밀번호 미기입으로 인한 회원가입 실패")
+    void signupFailedByNullPassword() throws Exception {
+        //given
+        UserSignupRequest userSignupRequest = UserSignupRequest.builder()
+                .loginId("testId")
+                .build();
+
+        String json = objectMapper.writeValueAsString(userSignupRequest);
+
+        //expected
+        mockMvc.perform(MockMvcRequestBuilders.post("/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print());
+    }
+}

--- a/src/test/java/com/study/ducks/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/study/ducks/domain/user/service/UserServiceImplTest.java
@@ -1,0 +1,74 @@
+package com.study.ducks.domain.user.service;
+
+import com.study.ducks.domain.user.dto.UserSignupRequest;
+import com.study.ducks.domain.user.entity.User;
+import com.study.ducks.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class UserServiceImplTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private EntityManager em;
+
+    @BeforeEach
+    void setUp() {userRepository.deleteAllInBatch();}
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void signup() {
+        //given
+        UserSignupRequest userSignupRequest = UserSignupRequest.builder()
+                .loginId("test")
+                .password("1234")
+                .build();
+
+        //when
+        userService.signup(userSignupRequest);
+
+        //then
+        List<User> users = userRepository.findAll();
+
+        assertThat(users.size()).isEqualTo(1);
+        assertThat(userRepository.count()).isEqualTo(1);
+        assertThat(users.get(0).getLoginId()).isEqualTo("test");
+        assertThat(users.get(0).getPassword()).isNotEqualTo("1234");
+    }
+
+    @Test
+    @DisplayName("아이디 중복으로 인한 회원가입 실패")
+    void signupFailedByDuplicateLoginId() {
+        //given
+        User user = User.builder()
+                .loginId("test")
+                .password("1234")
+                .build();
+        userRepository.save(user);
+
+        UserSignupRequest userSignupRequest = UserSignupRequest.builder()
+                .loginId("test")
+                .password("1234")
+                .build();
+
+        //then
+        //assertThatThrownBy(() -> userService.signup(userSignupRequest))
+        //        .isInstanceOf(IsExistedUser.class)
+        //        .message("이미 존재하는 아이디입니다.");
+        //todo exception 관련 작업 후 적용 예정
+    }
+}

--- a/src/test/java/com/study/ducks/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/study/ducks/domain/user/service/UserServiceImplTest.java
@@ -3,6 +3,7 @@ package com.study.ducks.domain.user.service;
 import com.study.ducks.domain.user.dto.UserSignupRequest;
 import com.study.ducks.domain.user.entity.User;
 import com.study.ducks.domain.user.repository.UserRepository;
+import com.study.ducks.exception.custom.IsExistedUser;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
@@ -66,9 +68,8 @@ class UserServiceImplTest {
                 .build();
 
         //then
-        //assertThatThrownBy(() -> userService.signup(userSignupRequest))
-        //        .isInstanceOf(IsExistedUser.class)
-        //        .message("이미 존재하는 아이디입니다.");
-        //todo exception 관련 작업 후 적용 예정
+        assertThatThrownBy(() -> userService.signup(userSignupRequest))
+                .isInstanceOf(IsExistedUser.class)
+                .hasMessage("이미 존재하는 아이디입니다.");
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,32 @@
+spring:
+  application:
+    name: ducks
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    url: jdbc:h2:mem:ducks;NON_KEYWORDS=USER
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    properties:
+      hibernate:
+        ddl-auto: create
+        format_sql: true
+        use_sql_comments: true
+    open-in-view: true
+
+server:
+  url: "http://localhost"
+  servlet:
+    encoding:
+      force-response: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace
+
+


### PR DESCRIPTION
### 1. config 설정 추가
- jpa audit
- querydsl

### 2. user, commission 기본 모듈 작성
- 샘플 http파일 작성(postman과 유사 인텔리제이 내장 기능. git으로 관리하는것 좋을것 같아 넣어놓았음)
- 각 엔티티는 BaseTimeEntity를 상속하여 createdAt, updateAt을 자동 설정하도록 해놓았음, 추후 필요하다면 createdBy, updatedBy도 선택적으로 적용 가능
- 회원가입 기능 샘플 코드 작성

### 3. 테스트 코드 관련 기본 모듈 및 샘플 코드 작성
- 각 테스트는 독립적으로 작동하여야 하며, 인메모리 디비가 아닐 경우 기존 데이터가 새로운 테스트에 영향을 미치면 안됨.
- 테스트 전 기존 데이터를 삭제. 테스트 종료 시점에 롤백 -> '@Transactional', '@BeforeEach' 사용

### 4. 공통 error 처리 모듈 작성
- ExceptionController를 사용하여 전역적으로 처리
- 상황에 맞게 커스텀 익셉션을 생성하여 에러 처리  