### PR TITLE
[feat] : # 5 / 세션 로그인, 로그아웃 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.modelmapper:modelmapper:3.1.1'
+
 
 }
 

--- a/src/main/java/com/study/ducks/config/ModelMapperConfig.java
+++ b/src/main/java/com/study/ducks/config/ModelMapperConfig.java
@@ -1,0 +1,24 @@
+package com.study.ducks.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.modelmapper.config.Configuration.AccessLevel;
+
+@Configuration
+public class ModelMapperConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+
+        ModelMapper modelMapper = new ModelMapper();
+        modelMapper.getConfiguration()
+                .setSkipNullEnabled(true)
+                .setFieldMatchingEnabled(true)   // 필드 기준으로 매핑 가능
+                .setFieldAccessLevel(AccessLevel.PRIVATE); // private 필드도 접근 가능
+
+        return modelMapper;
+
+    }
+
+}

--- a/src/main/java/com/study/ducks/config/SecurityConfig.java
+++ b/src/main/java/com/study/ducks/config/SecurityConfig.java
@@ -33,6 +33,8 @@ public class SecurityConfig {
                         .anyRequest().permitAll()
                 )
                 .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
                 .build();
     }
 

--- a/src/main/java/com/study/ducks/domain/login/controller/LoginController.java
+++ b/src/main/java/com/study/ducks/domain/login/controller/LoginController.java
@@ -3,6 +3,7 @@ package com.study.ducks.domain.login.controller;
 import com.study.ducks.domain.login.dto.KakaoUserInfoResponse;
 import com.study.ducks.domain.login.dto.LoginRequest;
 import com.study.ducks.domain.login.dto.LoginResponse;
+import com.study.ducks.domain.login.dto.SigninRequest;
 import com.study.ducks.domain.login.service.LoginService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,11 +24,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @Slf4j
 public class LoginController {
-    @Value("${spring.kakao.auth.client}")
-    private String clientId;
-    @Value("${spring.kakao.auth.redirect}")
-    private String redirectUrl;
-
     private final LoginService loginService;
 
     @Operation(summary = "일반 사용자 로그인", description = "일반 사용자 로그인")
@@ -53,4 +49,12 @@ public class LoginController {
         return ResponseEntity.ok()
                 .body(loginService.loginProcess(loginRequest));
     }
+
+    @Operation(summary = "일반 사용자 회원가입", description = "사용자 회원가입")
+    @PostMapping("/auth/logout")
+    public ResponseEntity<LoginResponse> signIn(HttpServletRequest httpServletRequest, @RequestBody @Validated SigninRequest signinRequest){
+        return ResponseEntity.ok()
+                .body(loginService.signInProcess(signinRequest));
+    }
+
 }

--- a/src/main/java/com/study/ducks/domain/login/controller/LoginController.java
+++ b/src/main/java/com/study/ducks/domain/login/controller/LoginController.java
@@ -1,0 +1,49 @@
+package com.study.ducks.domain.login.controller;
+
+import com.study.ducks.domain.login.dto.LoginRequest;
+import com.study.ducks.domain.login.dto.LoginResponse;
+import com.study.ducks.domain.login.service.LoginService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "로그인 API", description = "로그인 API 입니다.")
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class LoginController {
+
+    private final LoginService loginService;
+
+    @Operation(summary = "일반 사용자 로그인", description = "일반 사용자 로그인")
+    @PostMapping("/auth/login")
+    public ResponseEntity<LoginResponse> login(HttpServletRequest httpServletRequest, @RequestBody @Validated LoginRequest loginRequest){
+        httpServletRequest.getSession().invalidate();
+        HttpSession session = httpServletRequest.getSession();
+
+        LoginResponse loginResponse = loginService.loginProcess(loginRequest);
+        session.setAttribute("loginResponse", loginResponse);
+        session.setMaxInactiveInterval(1800);
+
+        return ResponseEntity.ok()
+                .body(loginResponse);
+    }
+
+    @Operation(summary = "일반 사용자 로그아웃", description = "일반 사용자 로그아웃")
+    @PostMapping("/auth/logout")
+    public ResponseEntity<LoginResponse> logout(HttpServletRequest httpServletRequest, @RequestBody @Validated LoginRequest loginRequest){
+        HttpSession session = httpServletRequest.getSession(false);
+        session.invalidate();
+
+        return ResponseEntity.ok()
+                .body(loginService.loginProcess(loginRequest));
+    }
+}

--- a/src/main/java/com/study/ducks/domain/login/controller/LoginController.java
+++ b/src/main/java/com/study/ducks/domain/login/controller/LoginController.java
@@ -1,25 +1,32 @@
 package com.study.ducks.domain.login.controller;
 
+import com.study.ducks.domain.login.dto.KakaoUserInfoResponse;
 import com.study.ducks.domain.login.dto.LoginRequest;
 import com.study.ducks.domain.login.dto.LoginResponse;
 import com.study.ducks.domain.login.service.LoginService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.ui.Model;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "로그인 API", description = "로그인 API 입니다.")
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 public class LoginController {
+    @Value("${spring.kakao.auth.client}")
+    private String clientId;
+    @Value("${spring.kakao.auth.redirect}")
+    private String redirectUrl;
 
     private final LoginService loginService;
 

--- a/src/main/java/com/study/ducks/domain/login/controller/SocialLoginController.java
+++ b/src/main/java/com/study/ducks/domain/login/controller/SocialLoginController.java
@@ -1,0 +1,46 @@
+package com.study.ducks.domain.login.controller;
+
+import com.study.ducks.domain.login.dto.KakaoUserInfoResponse;
+import com.study.ducks.domain.login.dto.LoginRequest;
+import com.study.ducks.domain.login.dto.LoginResponse;
+import com.study.ducks.domain.login.service.LoginService;
+import com.study.ducks.domain.login.service.SocialLoginService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class SocialLoginController {
+    @Value("${spring.kakao.auth.client}")
+    private String clientId;
+    @Value("${spring.kakao.auth.redirect}")
+    private String redirectUrl;
+
+    private final SocialLoginService socialLoginService;
+
+    @GetMapping("/login")
+    public String loginPage(Model model) {
+        String location = "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id="+clientId+"&redirect_uri="+redirectUrl;
+        model.addAttribute("location", location);
+
+        return "login";
+    }
+
+    @GetMapping("/oauth/login")
+    public ResponseEntity<?> callback(@RequestParam("code") String code) {
+        KakaoUserInfoResponse kakaoUserInfoResponse = socialLoginService.getUserInfo(code);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/study/ducks/domain/login/controller/UserInfoController.java
+++ b/src/main/java/com/study/ducks/domain/login/controller/UserInfoController.java
@@ -1,0 +1,48 @@
+package com.study.ducks.domain.login.controller;
+
+import com.study.ducks.domain.login.dto.LoginRequest;
+import com.study.ducks.domain.login.dto.LoginResponse;
+import com.study.ducks.domain.login.service.LoginService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class UserInfoController {
+
+
+    private final LoginService loginService;
+
+    @Operation(summary = "일반 사용자 로그인", description = "일반 사용자 로그인")
+    @PostMapping("/auth/login")
+    public ResponseEntity<LoginResponse> login(HttpServletRequest httpServletRequest, @RequestBody @Validated LoginRequest loginRequest){
+        httpServletRequest.getSession().invalidate();
+        HttpSession session = httpServletRequest.getSession();
+
+        LoginResponse loginResponse = loginService.loginProcess(loginRequest);
+        session.setAttribute("loginResponse", loginResponse);
+        session.setMaxInactiveInterval(1800);
+
+        return ResponseEntity.ok()
+                .body(loginResponse);
+    }
+
+    @Operation(summary = "일반 사용자 로그아웃", description = "일반 사용자 로그아웃")
+    @PostMapping("/auth/logout")
+    public ResponseEntity<LoginResponse> logout(HttpServletRequest httpServletRequest, @RequestBody @Validated LoginRequest loginRequest){
+        HttpSession session = httpServletRequest.getSession(false);
+        session.invalidate();
+
+        return ResponseEntity.ok()
+                .body(loginService.loginProcess(loginRequest));
+    }
+}

--- a/src/main/java/com/study/ducks/domain/login/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/study/ducks/domain/login/dto/KakaoTokenResponse.java
@@ -1,0 +1,27 @@
+package com.study.ducks.domain.login.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor //역직렬화를 위한 기본 생성자
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponse {
+
+        @JsonProperty("token_type")
+        public String tokenType;
+        @JsonProperty("access_token")
+        public String accessToken;
+        @JsonProperty("id_token")
+        public String idToken;
+        @JsonProperty("expires_in")
+        public Integer expiresIn;
+        @JsonProperty("refresh_token")
+        public String refreshToken;
+        @JsonProperty("refresh_token_expires_in")
+        public Integer refreshTokenExpiresIn;
+        @JsonProperty("scope")
+        public String scope;
+}

--- a/src/main/java/com/study/ducks/domain/login/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/study/ducks/domain/login/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,217 @@
+package com.study.ducks.domain.login.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.HashMap;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfoResponse {
+
+    //회원 번호
+    @Schema(description = "서비스에 연결 완료된 시각")
+    @JsonProperty("id")
+    public Long id;
+
+    //자동 연결 설정을 비활성화한 경우만 존재.
+    //true : 연결 상태, false : 연결 대기 상태
+    @Schema(description = "서비스에 연결 완료된 시각")
+    @JsonProperty("has_signed_up")
+    public Boolean hasSignedUp;
+
+    @Schema(description = "서비스에 연결 완료된 시각")
+    @JsonProperty("connected_at")
+    public Date connectedAt;
+
+    @Schema(description = "카카오싱크 간편가입을 통해 로그인한 시각")
+    @JsonProperty("synched_at")
+    public Date synchedAt;
+
+    //사용자 프로퍼티
+    @Schema(description = "서비스에 연결 완료된 시각")
+    @JsonProperty("properties")
+    public HashMap<String, String> properties;
+
+    //카카오 계정 정보
+    @Schema(description = "서비스에 연결 완료된 시각")
+    @JsonProperty("kakao_account")
+    public KakaoAccount kakaoAccount;
+
+    //uuid 등 추가 정보
+    @Schema(description = "서비스에 연결 완료된 시각")
+    @JsonProperty("for_partner")
+    public Partner partner;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class KakaoAccount {
+
+        @Schema(description = "프로필 정보 제공 동의 여부")
+        @JsonProperty("profile_needs_agreement")
+        public Boolean isProfileAgree;
+
+        @Schema(description = "닉네임 제공 동의 여부")
+        @JsonProperty("profile_nickname_needs_agreement")
+        public Boolean isNickNameAgree;
+
+        //프로필 사진 제공 동의 여부
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("profile_image_needs_agreement")
+        public Boolean isProfileImageAgree;
+
+        //사용자 프로필 정보
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("profile")
+        public Profile profile;
+
+        //이름 제공 동의 여부
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("name_needs_agreement")
+        public Boolean isNameAgree;
+
+        //카카오계정 이름
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("name")
+        public String name;
+
+        //이메일 제공 동의 여부
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("email_needs_agreement")
+        public Boolean isEmailAgree;
+
+        //이메일이 유효 여부
+        // true : 유효한 이메일, false : 이메일이 다른 카카오 계정에 사용돼 만료
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("is_email_valid")
+        public Boolean isEmailValid;
+
+        //이메일이 인증 여부
+        //true : 인증된 이메일, false : 인증되지 않은 이메일
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("is_email_verified")
+        public Boolean isEmailVerified;
+
+        //카카오계정 대표 이메일
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("email")
+        public String email;
+
+        //연령대 제공 동의 여부
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("age_range_needs_agreement")
+        public Boolean isAgeAgree;
+
+        //연령대
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("age_range")
+        public String ageRange;
+
+        //출생 연도 제공 동의 여부
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("birthyear_needs_agreement")
+        public Boolean isBirthYearAgree;
+
+        //출생 연도 (YYYY 형식)
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("birthyear")
+        public String birthYear;
+
+        //생일 제공 동의 여부
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("birthday_needs_agreement")
+        public Boolean isBirthDayAgree;
+
+        //생일 (MMDD 형식)
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("birthday")
+        public String birthDay;
+
+        //생일 타입
+        // SOLAR(양력) 혹은 LUNAR(음력)
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("birthday_type")
+        public String birthDayType;
+
+        //성별 제공 동의 여부
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("gender_needs_agreement")
+        public Boolean isGenderAgree;
+
+        //성별
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("gender")
+        public String gender;
+
+        //전화번호 제공 동의 여부
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("phone_number_needs_agreement")
+        public Boolean isPhoneNumberAgree;
+
+        //전화번호
+        //국내 번호인 경우 +82 00-0000-0000 형식
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("phone_number")
+        public String phoneNumber;
+
+        //CI 동의 여부
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("ci_needs_agreement")
+        public Boolean isCIAgree;
+
+        //CI, 연계 정보
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("ci")
+        public String ci;
+
+        //CI 발급 시각, UTC
+        @Schema(description = "서비스에 연결 완료된 시각")
+        @JsonProperty("ci_authenticated_at")
+        public Date ciCreatedAt;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public class Profile {
+
+            //닉네임
+            @JsonProperty("nickname")
+            public String nickName;
+
+            //프로필 미리보기 이미지 URL
+            @JsonProperty("thumbnail_image_url")
+            public String thumbnailImageUrl;
+
+            //프로필 사진 URL
+            @JsonProperty("profile_image_url")
+            public String profileImageUrl;
+
+            //프로필 사진 URL 기본 프로필인지 여부
+            //true : 기본 프로필, false : 사용자 등록
+            @JsonProperty("is_default_image")
+            public String isDefaultImage;
+
+            //닉네임이 기본 닉네임인지 여부
+            //true : 기본 닉네임, false : 사용자 등록
+            @JsonProperty("is_default_nickname")
+            public Boolean isDefaultNickName;
+
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class Partner {
+        //고유 ID
+        @JsonProperty("uuid")
+        public String uuid;
+    }
+
+}

--- a/src/main/java/com/study/ducks/domain/login/dto/LoginRequest.java
+++ b/src/main/java/com/study/ducks/domain/login/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.study.ducks.domain.login.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(title="로그인 요청")
+public record LoginRequest(
+        @Schema(description = "아이디", example = "qwerty")
+        @NotBlank
+        String loginId,
+        @Schema(description = "비밀번호", example = "1234")
+        @NotBlank
+        String password
+) {
+
+}

--- a/src/main/java/com/study/ducks/domain/login/dto/LoginResponse.java
+++ b/src/main/java/com/study/ducks/domain/login/dto/LoginResponse.java
@@ -1,0 +1,32 @@
+package com.study.ducks.domain.login.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.http.HttpStatus;
+
+@Schema(title = "로그인 응답")
+public record LoginResponse(
+        @Schema(description = "회원 ID",example = "qwerty")
+        String loginId,
+        @Schema(description = "닉네임",example = "qwerty")
+        String nickname,
+        @Schema(description = "국가코드")
+        String countryCode,
+        @Schema(description = "이메일",example = "jjlim940224@gamil.com")
+        String email,
+        @Schema(description = "전화번호",example = "01012345678")
+        String phone,
+        @Schema(description = "권한",example = "1")
+        String role,
+        @Schema(description = "응답 메세지",example = "1")
+        String responseMessage,
+        @Schema(description = "응답 코드",example = "1")
+        int httpStatus
+        ) {
+        public LoginResponse(String responseMessage, int httpStatus){
+               this(null,null,null,null,null,null,responseMessage,httpStatus);
+        }
+        public LoginResponse(String loginId){
+                this(loginId,null,null,null,null,null,null,HttpStatus.OK.value());
+        }
+
+}

--- a/src/main/java/com/study/ducks/domain/login/dto/SigninRequest.java
+++ b/src/main/java/com/study/ducks/domain/login/dto/SigninRequest.java
@@ -1,0 +1,16 @@
+package com.study.ducks.domain.login.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(title="로그인 요청")
+public record SigninRequest(
+        @Schema(description = "아이디", example = "qwerty")
+        @NotBlank
+        String loginId,
+        @Schema(description = "비밀번호", example = "1234")
+        @NotBlank
+        String password
+) {
+
+}

--- a/src/main/java/com/study/ducks/domain/login/dto/SigninResponse.java
+++ b/src/main/java/com/study/ducks/domain/login/dto/SigninResponse.java
@@ -1,0 +1,32 @@
+package com.study.ducks.domain.login.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.http.HttpStatus;
+
+@Schema(title = "로그인 응답")
+public record SigninResponse(
+        @Schema(description = "회원 ID",example = "qwerty")
+        String loginId,
+        @Schema(description = "닉네임",example = "qwerty")
+        String nickname,
+        @Schema(description = "국가코드")
+        String countryCode,
+        @Schema(description = "이메일",example = "jjlim940224@gamil.com")
+        String email,
+        @Schema(description = "전화번호",example = "01012345678")
+        String phone,
+        @Schema(description = "권한",example = "1")
+        String role,
+        @Schema(description = "응답 메세지",example = "1")
+        String responseMessage,
+        @Schema(description = "응답 코드",example = "1")
+        int httpStatus
+        ) {
+        public SigninResponse(String responseMessage, int httpStatus){
+               this(null,null,null,null,null,null,responseMessage,httpStatus);
+        }
+        public SigninResponse(String loginId){
+                this(loginId,null,null,null,null,null,null,HttpStatus.OK.value());
+        }
+
+}

--- a/src/main/java/com/study/ducks/domain/login/repository/LoginRepository.java
+++ b/src/main/java/com/study/ducks/domain/login/repository/LoginRepository.java
@@ -1,0 +1,12 @@
+package com.study.ducks.domain.login.repository;
+
+import com.study.ducks.domain.user.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LoginRepository  extends JpaRepository<Users, Long> {
+    Optional<Users> findByLoginId(String loginId);
+}

--- a/src/main/java/com/study/ducks/domain/login/service/LoginService.java
+++ b/src/main/java/com/study/ducks/domain/login/service/LoginService.java
@@ -1,0 +1,11 @@
+package com.study.ducks.domain.login.service;
+
+import com.study.ducks.domain.login.dto.LoginRequest;
+import com.study.ducks.domain.login.dto.LoginResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface LoginService {
+    public LoginResponse loginProcess(LoginRequest loginRequest);
+    public void logoutProcess(LoginRequest loginRequest);
+}

--- a/src/main/java/com/study/ducks/domain/login/service/LoginService.java
+++ b/src/main/java/com/study/ducks/domain/login/service/LoginService.java
@@ -2,9 +2,8 @@ package com.study.ducks.domain.login.service;
 
 import com.study.ducks.domain.login.dto.LoginRequest;
 import com.study.ducks.domain.login.dto.LoginResponse;
-import org.springframework.stereotype.Service;
 
-@Service
+
 public interface LoginService {
     public LoginResponse loginProcess(LoginRequest loginRequest);
     public void logoutProcess(LoginRequest loginRequest);

--- a/src/main/java/com/study/ducks/domain/login/service/LoginService.java
+++ b/src/main/java/com/study/ducks/domain/login/service/LoginService.java
@@ -2,9 +2,14 @@ package com.study.ducks.domain.login.service;
 
 import com.study.ducks.domain.login.dto.LoginRequest;
 import com.study.ducks.domain.login.dto.LoginResponse;
+import com.study.ducks.domain.login.dto.SigninRequest;
+import com.study.ducks.domain.login.dto.SigninResponse;
 
 
 public interface LoginService {
     public LoginResponse loginProcess(LoginRequest loginRequest);
     public void logoutProcess(LoginRequest loginRequest);
+    public LoginResponse signInProcess(SigninRequest signinRequest);
+    public LoginResponse singOutProcess(Long id);
+
 }

--- a/src/main/java/com/study/ducks/domain/login/service/LoginServiceImpl.java
+++ b/src/main/java/com/study/ducks/domain/login/service/LoginServiceImpl.java
@@ -1,11 +1,10 @@
 package com.study.ducks.domain.login.service;
 
-import com.study.ducks.domain.login.dto.KakaoUserInfoResponse;
-import com.study.ducks.domain.login.dto.LoginRequest;
-import com.study.ducks.domain.login.dto.LoginResponse;
+import com.study.ducks.domain.login.dto.*;
 import com.study.ducks.domain.user.entity.Users;
 import com.study.ducks.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,7 +19,8 @@ public class LoginServiceImpl implements LoginService{
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final SocialLoginService socialLoginService;
+    private final ModelMapper modelMapper;
+
 
     @Override
     public LoginResponse loginProcess(LoginRequest loginRequest) {
@@ -59,4 +59,20 @@ public class LoginServiceImpl implements LoginService{
     @Override
     public void logoutProcess(LoginRequest loginRequest) {
     }
+
+    @Override
+    public LoginResponse signInProcess(SigninRequest signinRequest) {
+        Users users = modelMapper.map(signinRequest, Users.class);
+        LoginResponse loginResponse = modelMapper.map(userRepository.save(users), LoginResponse.class);
+
+        return loginResponse;
+    }
+
+    @Override
+    public LoginResponse singOutProcess(Long id) {
+        return null;
+    }
+
+
+
 }

--- a/src/main/java/com/study/ducks/domain/login/service/LoginServiceImpl.java
+++ b/src/main/java/com/study/ducks/domain/login/service/LoginServiceImpl.java
@@ -1,0 +1,60 @@
+package com.study.ducks.domain.login.service;
+
+import com.study.ducks.domain.login.dto.LoginRequest;
+import com.study.ducks.domain.login.dto.LoginResponse;
+import com.study.ducks.domain.user.entity.Users;
+import com.study.ducks.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LoginServiceImpl implements LoginService{
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public LoginResponse loginProcess(LoginRequest loginRequest) {
+
+        Optional<Users> users = userRepository.findByLoginId(loginRequest.loginId());
+
+        String encodedPassword = passwordEncoder.encode(loginRequest.password());
+
+        if(users.isPresent()){
+            Users user = users.get();
+            if(user.getPassword().equals(encodedPassword) ){
+                return new LoginResponse(
+                        user.getLoginId()
+                        ,user.getNickname()
+                        ,user.getCountryCode()
+                        ,user.getEmail()
+                        ,user.getPhone()
+                        ,user.getRole()
+                        ,"login success"
+                        , HttpStatus.OK.value()
+                );
+            }else{
+                return new LoginResponse(
+                        "password incorrect"
+                        , HttpStatus.OK.value()
+                );
+            }
+        }
+
+        return new LoginResponse(
+                "User not found"
+                , HttpStatus.OK.value()
+        );
+    }
+
+    @Override
+    public void logoutProcess(LoginRequest loginRequest) {
+    }
+}

--- a/src/main/java/com/study/ducks/domain/login/service/LoginServiceImpl.java
+++ b/src/main/java/com/study/ducks/domain/login/service/LoginServiceImpl.java
@@ -1,5 +1,6 @@
 package com.study.ducks.domain.login.service;
 
+import com.study.ducks.domain.login.dto.KakaoUserInfoResponse;
 import com.study.ducks.domain.login.dto.LoginRequest;
 import com.study.ducks.domain.login.dto.LoginResponse;
 import com.study.ducks.domain.user.entity.Users;
@@ -19,6 +20,7 @@ public class LoginServiceImpl implements LoginService{
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final SocialLoginService socialLoginService;
 
     @Override
     public LoginResponse loginProcess(LoginRequest loginRequest) {

--- a/src/main/java/com/study/ducks/domain/login/service/SocialLoginService.java
+++ b/src/main/java/com/study/ducks/domain/login/service/SocialLoginService.java
@@ -1,0 +1,8 @@
+package com.study.ducks.domain.login.service;
+
+import com.study.ducks.domain.login.dto.KakaoUserInfoResponse;
+
+public interface SocialLoginService {
+    public String getAccessTokenFromKakao(String code);
+    public KakaoUserInfoResponse getUserInfo(String code);
+}

--- a/src/main/java/com/study/ducks/domain/login/service/SocialLoginServiceImpl.java
+++ b/src/main/java/com/study/ducks/domain/login/service/SocialLoginServiceImpl.java
@@ -1,0 +1,75 @@
+package com.study.ducks.domain.login.service;
+
+import com.study.ducks.domain.login.dto.KakaoTokenResponse;
+import com.study.ducks.domain.login.dto.KakaoUserInfoResponse;
+import com.study.ducks.exception.custom.LoginUserException;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@Slf4j
+@Transactional(readOnly = true)
+public class SocialLoginServiceImpl implements SocialLoginService{
+
+    private String clientId;
+    private String redirectUri;
+    private final String KAUTH_TOKEN_URL_HOST;
+    private final String KAUTH_USER_URL_HOST;
+
+    @Autowired
+    public SocialLoginServiceImpl(@Value("${spring.kakao.auth.client}") String clientId,@Value("${spring.kakao.auth.redirect}") String redirectUri) {
+        this.clientId = clientId;
+        this.redirectUri = redirectUri;
+        KAUTH_TOKEN_URL_HOST ="https://kauth.kakao.com";
+        KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
+    }
+
+     public String getAccessTokenFromKakao(String code) {
+        KakaoTokenResponse kakaoTokenResponse =  WebClient.create(KAUTH_TOKEN_URL_HOST).post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/oauth/token")
+                        .queryParam("grant_type","authorization_code")
+                        .queryParam("client_id",clientId)
+                        .queryParam("redirect_uri",redirectUri)
+                        .queryParam("code",code)
+                        .build())
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new LoginUserException("Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new LoginUserException("Internal Server Error")))
+                .bodyToMono(KakaoTokenResponse.class)
+                .block();
+
+        return kakaoTokenResponse.getAccessToken();
+    }
+
+    public KakaoUserInfoResponse getUserInfo(String code) {
+        String accessToken = this.getAccessTokenFromKakao(code);
+        KakaoUserInfoResponse userInfo = WebClient.create(KAUTH_USER_URL_HOST)
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/v2/user/me")
+                        .build())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                //TODO : Custom Exception
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new LoginUserException("Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new LoginUserException("Internal Server Error")))
+                .bodyToMono(KakaoUserInfoResponse.class)
+                .block();
+
+        return userInfo;
+    }
+}

--- a/src/main/java/com/study/ducks/domain/login/service/UserInfoService.java
+++ b/src/main/java/com/study/ducks/domain/login/service/UserInfoService.java
@@ -1,0 +1,10 @@
+package com.study.ducks.domain.login.service;
+
+import com.study.ducks.domain.login.dto.LoginRequest;
+import com.study.ducks.domain.login.dto.LoginResponse;
+
+
+public interface UserInfoService  {
+    public LoginResponse loginProcess(LoginRequest loginRequest);
+    public void logoutProcess(LoginRequest loginRequest);
+}

--- a/src/main/java/com/study/ducks/domain/login/service/UserInfoServiceImpl.java
+++ b/src/main/java/com/study/ducks/domain/login/service/UserInfoServiceImpl.java
@@ -1,0 +1,24 @@
+package com.study.ducks.domain.login.service;
+
+import com.study.ducks.domain.login.dto.LoginRequest;
+import com.study.ducks.domain.login.dto.LoginResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Slf4j
+@Transactional(readOnly = true)
+public class UserInfoServiceImpl  implements UserInfoService {
+
+    @Override
+    public LoginResponse loginProcess(LoginRequest loginRequest) {
+        return null;
+    }
+
+    @Override
+    public void logoutProcess(LoginRequest loginRequest) {
+
+    }
+}

--- a/src/main/java/com/study/ducks/domain/user/dto/UserInfoDTO.java
+++ b/src/main/java/com/study/ducks/domain/user/dto/UserInfoDTO.java
@@ -1,0 +1,16 @@
+package com.study.ducks.domain.user.dto;
+
+public class UserInfoDTO {
+    private Long usersId;
+    private String loginId;
+    private String password;
+    //private String name;
+    private String nickname;
+    private String address;
+    private String countryCode;
+    private String phone;
+    private String role;
+    private String email;
+    private Boolean isAuth;
+    private Boolean isActive;
+}

--- a/src/main/java/com/study/ducks/domain/user/entity/Users.java
+++ b/src/main/java/com/study/ducks/domain/user/entity/Users.java
@@ -1,6 +1,7 @@
 package com.study.ducks.domain.user.entity;
 
 import com.study.ducks.common.BaseTimeEntity;
+import com.study.ducks.domain.user.dto.UserInfoDTO;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;

--- a/src/main/java/com/study/ducks/exception/custom/LoginUserException.java
+++ b/src/main/java/com/study/ducks/exception/custom/LoginUserException.java
@@ -1,0 +1,22 @@
+package com.study.ducks.exception.custom;
+
+import com.study.ducks.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class LoginUserException extends ApiException {
+
+    private int httpStatus = HttpStatus.BAD_REQUEST.value();
+
+    public LoginUserException(String message) {
+        super(message);
+    }
+
+    public LoginUserException(String message,int httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+    @Override
+    public int getStatusCode() {
+        return httpStatus;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
         format_sql: true
         use_sql_comments: true
     open-in-view: true
+  kakao:
+     auth:
+       client: e0db81143185744eb51e733dc1a26896
+       redirect: http://localhost:8081/oauth/login
 server:
   servlet:
     session:

--- a/src/test/java/com/study/ducks/domain/login/LoginServiceImplTest.java
+++ b/src/test/java/com/study/ducks/domain/login/LoginServiceImplTest.java
@@ -1,0 +1,58 @@
+package com.study.ducks.domain.login;
+
+import com.study.ducks.domain.login.dto.LoginRequest;
+import com.study.ducks.domain.login.dto.LoginResponse;
+import com.study.ducks.domain.login.repository.LoginRepository;
+import com.study.ducks.domain.login.service.LoginServiceImpl;
+import com.study.ducks.domain.user.dto.UserSignupRequest;
+import com.study.ducks.domain.user.repository.UserRepository;
+import com.study.ducks.domain.user.service.UserServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LoginServiceImplTest {
+
+    @InjectMocks
+    private LoginServiceImpl loginService;
+    @InjectMocks
+    private UserServiceImpl userService;
+    @Mock
+    private LoginRepository loginRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+
+    @Test
+    void doLogin() {
+        UserSignupRequest userSignupRequest = UserSignupRequest.builder()
+                .loginId("test")
+                .password("1234")
+                .build();
+        userService.signup(userSignupRequest);
+
+        //given
+        LoginRequest loginRequest = new LoginRequest("test","1234");
+        LoginResponse fakeLoginResponse = new LoginResponse("test");
+        String fakeEncodedPassword = passwordEncoder.encode("1234");
+
+        //when
+        when(passwordEncoder.matches("1234", fakeEncodedPassword)).thenReturn(true);
+        LoginResponse loginResponse = loginService.loginProcess(loginRequest);
+
+        //then
+        assertNotNull(loginResponse);
+        assertEquals(fakeLoginResponse, loginResponse);
+    }
+
+}


### PR DESCRIPTION
Ducks
[feat] : # 5 / 세션 로그인, 로그아웃 작업

사용자가 로그인을  할 때 사용자 계정에 대한 비밀번호가 맞는지 확인한다.
로그인 정보가 일치하면 session을 생성하고 회원id 와 nickname등의 회원정보를 저장한다.
백엔드에서는 API를 제공하고, 프론트엔드에서는 회원id, 닉네임,email,전화번호,국가코드 정보를 전달받는다. 

💬 공유사항 to 리뷰어
아직 테스트가 완료되지 않았습니다. 

PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

 커밋 메시지 컨벤션에 맞게 작성했습니다.
 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
Closes (생략해도 됨)